### PR TITLE
increase page size for strapi news fetches

### DIFF
--- a/ui/_data/news.js
+++ b/ui/_data/news.js
@@ -3,10 +3,11 @@ require("dotenv").config();
 const { default: axios } = require("axios");
 
 const apiUrl = process.env.API_URL;
+const apiPageSize = 500;
 
 module.exports = async () => {
   try {
-    const res = await axios.get(`${apiUrl}/news-items`);
+    const res = await axios.get(`${apiUrl}/news-items?_limit=${apiPageSize}`);
     return res.data;
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
In Strapi 3.x, API page size is 100 by default. Because of that, news stopped appearing on the site. This will require a rework in the future, but for now I'll just increase this limit.