### PR TITLE
request 500 items per page for all strapi entity types

### DIFF
--- a/ui/_data/docs.js
+++ b/ui/_data/docs.js
@@ -3,10 +3,11 @@ require("dotenv").config();
 const { default: axios } = require("axios");
 
 const apiUrl = process.env.API_URL;
+const apiPageSize = 500;
 
 module.exports = async () => {
   try {
-    const res = await axios.get(`${apiUrl}/docs`);
+    const res = await axios.get(`${apiUrl}/docs?_limit=${apiPageSize}`);
     return res.data;
   } catch (error) {
     console.error(error);

--- a/ui/_data/pages.js
+++ b/ui/_data/pages.js
@@ -3,10 +3,11 @@ require("dotenv").config();
 const { default: axios } = require("axios");
 
 const apiUrl = process.env.API_URL;
+const apiPageSize = 500;
 
 module.exports = async () => {
   try {
-    const res = await axios.get(`${apiUrl}/pages`);
+    const res = await axios.get(`${apiUrl}/pages?_limit=${apiPageSize}`);
     return res.data;
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
We ran into the same issue for docs when we created a 101st doc. This applies https://github.com/maii-chgk/maii-site/pull/22 to two other active strapi entity types (docs and pages). We don’t create any other entities at the moment.